### PR TITLE
fix: replace deprecated google doc integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "lint": "eslint --ext .js,.vue src"
   },
   "dependencies": {
-    "get-json": "1.0.0",
     "image-preloader": "^1.1.1",
     "lodash": "4.14.2",
     "vue": "^2.4.2",

--- a/src/utils/getGoogleJsonSheet.js
+++ b/src/utils/getGoogleJsonSheet.js
@@ -1,0 +1,5 @@
+export const getGoogleJsonSheet = async (sheetId) => {
+  return fetch(`https://docs.google.com/spreadsheets/d/${sheetId}/gviz/tq?tqx=out:json`)
+      .then(res => res.text())
+      .then(text => JSON.parse(text.substr(47).slice(0, -2)))
+}


### PR DESCRIPTION
Fix Google doc integration using this article:
https://benborgers.com/posts/google-sheets-json

I saw that a better integration would have been to connect directly to the GoogleDocs API instead of downloading the Json file that is not more a json file... but this is a quick fix that makes everything works again

new data structure 
<img width="721" alt="Screen Shot 2021-09-08 at 12 24 09 PM" src="https://user-images.githubusercontent.com/954888/132565875-a074d724-0fbb-4cac-a49a-6f573f5cbde1.png">


Site working again in local
<img width="1918" alt="Screen Shot 2021-09-08 at 2 23 15 PM" src="https://user-images.githubusercontent.com/954888/132565972-c56be8e0-20ef-4ae2-8acf-5ce9f13351b0.png">




